### PR TITLE
Fix ReactFlightDOMEdge test timing

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1191,16 +1191,17 @@ describe('ReactFlightDOMEdge', () => {
         name: 'Greeting',
         env: 'Server',
       });
+      const base = lazyWrapper._debugInfo[0].time;
       expect(lazyWrapper._debugInfo).toEqual([
-        {time: 12},
+        {time: base},
         greetInfo,
-        {time: 13},
+        {time: base + 1},
         expect.objectContaining({
           name: 'Container',
           env: 'Server',
           owner: greetInfo,
         }),
-        {time: 14},
+        {time: base + 2},
       ]);
       // The owner that created the span was the outer server component.
       // We expect the debug info to be referentially equal to the owner.


### PR DESCRIPTION
## Summary
- update timing assertions in ReactFlightDOMEdge test

## Testing
- `yarn lint`
- `node ./scripts/jest/jest-cli.js packages/react-dom/src/__tests__/ReactMultiChildText-test.js --runTestsByPath`
- `node ./scripts/jest/jest-cli.js packages/react-server/src/__tests__/ReactServer-test.js --runTestsByPath`
- `node ./scripts/jest/jest-cli.js packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js --runTestsByPath`


